### PR TITLE
Added ”Show latest savegames first” checkbox

### DIFF
--- a/scripts/guichan.lua
+++ b/scripts/guichan.lua
@@ -357,7 +357,8 @@ function AddMenuHelpers(menu)
   end
 
   function menu:addBrowser(path, filter, x, y, w, h, default, show_subfolders)
-    
+    local sortMode = 0
+
     -- Andrettin: make it so that it is possible to have a browser without showing subfolders
     if (show_subfolders == nil) then
     	show_subfolders = true
@@ -378,7 +379,12 @@ function AddMenuHelpers(menu)
         end
       end
 
-      local fileslist = ListFilesInDirectory(path)
+      local fileslist
+      if (sortMode == 0) then
+        fileslist = ListFilesInDirectory(path)
+      else
+        fileslist = ListFilesInDirectorySortByTime(path)
+      end
       for i,f in ipairs(fileslist) do
         if (string.find(f, filter)) then
           dirlist[u] = f
@@ -472,6 +478,16 @@ function AddMenuHelpers(menu)
     bq.oldSetActionCallback = bq.setActionCallback
     function bq:setActionCallback(cb)
       bq.actioncb = cb
+    end
+
+    function bq:sortByName()
+      sortMode = 0
+      updatelist()
+    end
+
+    function bq:sortByTime()
+      sortMode = 1
+      updatelist()
     end
 
     return bq

--- a/scripts/menus/load.lua
+++ b/scripts/menus/load.lua
@@ -27,7 +27,7 @@ end
 function AddLoadGameItems(menu)
 	menu:addLabel(_("Load Game"), 384 / 2, 11)
 	local browser = menu:addBrowser("~save", "^.*%.sav%.?g?z?$",
-		(384 - 300 - 18) / 2, 11 + (36 * 1.5), 318, 126)
+		(384 - 300 - 18) / 2, 11 + 36, 318, 126)
 
 	menu:addHalfButton(_("~!Load"), "l", (384 - 300 - 18) / 2, 256 - 16 - 27,
 	function()
@@ -42,6 +42,21 @@ function AddLoadGameItems(menu)
 			menu:stop()
 		end
 	end)
+	sortByCheckBox = menu:addImageCheckBox(_("Show latest savegames first"), (384 - 300 - 18) / 2, 256 - 16 - 27 - 25,
+	function()
+		wyr.preferences.SortSaveGamesByTime = sortByCheckBox:isMarked()
+		SavePreferences()
+
+		if (wyr.preferences.SortSaveGamesByTime) then
+			browser:sortByTime()
+		else
+			browser:sortByName()
+		end
+	end)
+	sortByCheckBox:setMarked(wyr.preferences.SortSaveGamesByTime)
+	if (wyr.preferences.SortSaveGamesByTime) then
+		browser:sortByTime()
+	end
 	menu:addHalfButton(_("~!Cancel"), "c", 384 - ((384 - 300 - 18) / 2) - 106, 256 - 16 - 27,
 	function() menu:stop() end)
 end

--- a/scripts/menus/save.lua
+++ b/scripts/menus/save.lua
@@ -56,10 +56,10 @@ function RunSaveMenu()
   menu:addLabel("Save Game", 384 / 2, 11)
 
   local t = menu:addTextInputField("game.sav",
-    (384 - 300 - 18) / 2, 11 + 36, 318)
+    (384 - 300 - 18) / 2, 11 + 24, 318)
 
   local browser = menu:addBrowser("~save", ".sav.gz$",
-    (384 - 300 - 18) / 2, 11 + 36 + 22, 318, 126)
+    (384 - 300 - 18) / 2, 11 + 24 + 22, 318, 126)
   local function cb(s)
     t:setText(browser:getSelectedItem())
   end
@@ -90,6 +90,22 @@ function RunSaveMenu()
         RunSaveGame(name, menu)
       end
     end)
+
+	sortByCheckBox = menu:addImageCheckBox(_("Show latest savegames first"), (384 - 300 - 18) / 2, 256 - 16 - 27 - 25,
+	function()
+		wyr.preferences.SortSaveGamesByTime = sortByCheckBox:isMarked()
+		SavePreferences()
+
+		if (wyr.preferences.SortSaveGamesByTime) then
+			browser:sortByTime()
+		else
+			browser:sortByName()
+		end
+	end)
+	sortByCheckBox:setMarked(wyr.preferences.SortSaveGamesByTime)
+	if (wyr.preferences.SortSaveGamesByTime) then
+		browser:sortByTime()
+	end
 
   menu:addHalfButton(_("~!Cancel"), "c", 384 - ((384 - 300 - 18) / 2) - 106, 256 - 16 - 27,
     function() menu:stop() end)

--- a/scripts/stratagus.lua
+++ b/scripts/stratagus.lua
@@ -1954,7 +1954,8 @@ local defaultPreferences = {
 	TipsShown = {},
 	LastVersionPlayed = "0.0.0",
 	EnabledMods = {},
-	GrandStrategySaveGames = {}
+	GrandStrategySaveGames = {},
+	SortSaveGamesByTime = false
 }
 
 CompleteMissingValues(wyr.preferences, defaultPreferences)


### PR DESCRIPTION
Added a checkbox on load/save menu to ”Show latest savegames first”, makes easier to find latest used savegames
The checkbox is saved to preference SortSaveGamesByTime

This needs changes to wyrmgus too: https://github.com/marcelofg55/Wyrmgus/commit/0957397e42568547eba0d30b94074aceee400f6d
