### PR TITLE
CMake: Configurable installation BINDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,13 @@
 project(wyrmsun)
 cmake_minimum_required(VERSION 3.0)
 
+set(BINDIR bin CACHE STRING "Where to install Wyrmsun launch script")
 set(DATADIR share/wyrmsun CACHE STRING "Where to install Wyrmsun data files")
 set(DOCSDIR share/doc/wyrmsun CACHE STRING "Where to install Wyrmsun documentation")
 
 configure_file(linux/wyrmsun.sh.in linux/wyrmsun.sh @ONLY)
 
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/linux/wyrmsun.sh DESTINATION bin RENAME wyrmsun)
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/linux/wyrmsun.sh DESTINATION ${BINDIR} RENAME wyrmsun)
 install(FILES linux/wyrmsun.desktop DESTINATION share/applications)
 install(FILES linux/wyrmsun.appdata.xml DESTINATION share/appdata)
 install(FILES graphics/ui/icons/wyrmsun_icon_32.png DESTINATION share/icons/hicolor/32x32/apps RENAME wyrmsun.png)


### PR DESCRIPTION
Some distros put their game binaries in `/usr/games` instead of `/usr/bin`.

I used `BINDIR` defaulting to `bin` to preserve compatibility, but note that Wyrmgus gets installed into `/usr/games` by default as it uses `GAMEDIR` (even though `BINDIR` is also defined in the Stratagus boilerplate): https://github.com/Andrettin/Wyrmgus/blob/master/CMakeLists.txt#L1249